### PR TITLE
Bump dependencies for Laravel 11 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ get realtime analytics, and receive instant insights.
 
 ## Requirements
 
-Requires PHP 8.1, and Laravel 10.
+This package requires PHP 8.1 or higher and Laravel 10.0 or higher. 
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^8.3",
+        "php": "^8.1 || ^8.2 || ^8.3",
         "guzzlehttp/guzzle": "^7.7",
         "laravel/framework": "^10.0.0 || ^11.0.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,19 +18,19 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "guzzlehttp/guzzle": "^7.7",
-        "laravel/framework": "^10.0.0"
+        "laravel/framework": "^10.0.0 || ^11.0.0"
     },
     "require-dev": {
+        "larastan/larastan": "^2.9",
         "laravel/pint": "^1.10",
-        "nunomaduro/larastan": "^2.6",
-        "orchestra/testbench": "^7.0 || ^8.0",
+        "orchestra/testbench": "^7.0 || ^8.0 || ^9.0",
         "pestphp/pest": "^2.13",
         "pestphp/pest-plugin-laravel": "^2.2",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-deprecation-rules": "^1.1",
-        "rector/rector": "^0.17.12",
+        "rector/rector": "^1.0.0",
         "thecodingmachine/phpstan-safe-rule": "^1.2"
     },
     "minimum-stability": "stable",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-  - vendor/nunomaduro/larastan/extension.neon
+  - vendor/larastan/larastan/extension.neon
   - vendor/phpstan/phpstan-deprecation-rules/rules.neon
   - vendor/thecodingmachine/phpstan-safe-rule/phpstan-safe-rule.neon
 


### PR DESCRIPTION
Currently, the package cannot be installed on a Laravel 11 project.

This PR upgrades dependencies making it compatible with Laravel 11. No other code changes were required, the test suite works perfectly after the upgrades.

It differs from #1  because it also upgrades other dependencies and switches to `larastan/larastan` because `nunomaduro/larastan` is now abandoned.